### PR TITLE
Fix the mask_ind used in the absorption profile

### DIFF
--- a/multi_dlas/process_qsos_multiple_dlas_meanflux.m
+++ b/multi_dlas/process_qsos_multiple_dlas_meanflux.m
@@ -159,7 +159,7 @@ for quasar_ind = 1:num_quasars
   this_rest_wavelengths = emitted_wavelengths(this_wavelengths, z_qso);
 
   unmasked_ind = (this_rest_wavelengths >= min_lambda) & ...
-        (this_rest_wavelengths <= max_lambda);
+                 (this_rest_wavelengths <= max_lambda);
 
   % keep complete copy of equally spaced wavelengths for absorption
   % computation

--- a/multi_dlas/process_qsos_multiple_dlas_meanflux.m
+++ b/multi_dlas/process_qsos_multiple_dlas_meanflux.m
@@ -158,14 +158,14 @@ for quasar_ind = 1:num_quasars
   % convert to QSO rest frame
   this_rest_wavelengths = emitted_wavelengths(this_wavelengths, z_qso);
 
-  ind = (this_rest_wavelengths >= min_lambda) & ...
+  unmasked_ind = (this_rest_wavelengths >= min_lambda) & ...
         (this_rest_wavelengths <= max_lambda);
 
   % keep complete copy of equally spaced wavelengths for absorption
   % computation
-  this_unmasked_wavelengths = this_wavelengths(ind);
+  this_unmasked_wavelengths = this_wavelengths(unmasked_ind);
 
-  ind = ind & (~this_pixel_mask);
+  ind = unmasked_ind & (~this_pixel_mask);
 
   this_wavelengths      =      this_wavelengths(ind);
   this_rest_wavelengths = this_rest_wavelengths(ind);
@@ -325,7 +325,9 @@ for quasar_ind = 1:num_quasars
       ];
 
   % to retain only unmasked pixels from computed absorption profile
-  mask_ind = (~this_pixel_mask(ind));
+  % this has to be done by using the unmasked_ind which has not yet
+  % been applied this_pixel_mask.
+  mask_ind = (~this_pixel_mask(unmasked_ind));
 
   for num_dlas = 1:max_dlas
     % compute probabilities under DLA model for each of the sampled

--- a/process_qsos.m
+++ b/process_qsos.m
@@ -103,7 +103,8 @@ for quasar_ind = 1:num_quasars
 
   unmasked_ind = (this_rest_wavelengths >= min_lambda) & ...
         (this_rest_wavelengths <= max_lambda);
-
+  unmasked_ind = (this_rest_wavelengths >= min_lambda) & ...
+                 (this_rest_wavelengths <= max_lambda);
   % keep complete copy of equally spaced wavelengths for absorption
   % computation
   this_unmasked_wavelengths = this_wavelengths(unmasked_ind);

--- a/process_qsos.m
+++ b/process_qsos.m
@@ -101,14 +101,14 @@ for quasar_ind = 1:num_quasars
   % convert to QSO rest frame
   this_rest_wavelengths = emitted_wavelengths(this_wavelengths, z_qso);
 
-  ind = (this_rest_wavelengths >= min_lambda) & ...
+  unmasked_ind = (this_rest_wavelengths >= min_lambda) & ...
         (this_rest_wavelengths <= max_lambda);
 
   % keep complete copy of equally spaced wavelengths for absorption
   % computation
-  this_unmasked_wavelengths = this_wavelengths(ind);
+  this_unmasked_wavelengths = this_wavelengths(unmasked_ind);
 
-  ind = ind & (~this_pixel_mask);
+  ind = unmasked_ind & (~this_pixel_mask);
 
   this_wavelengths      =      this_wavelengths(ind);
   this_rest_wavelengths = this_rest_wavelengths(ind);
@@ -177,7 +177,9 @@ for quasar_ind = 1:num_quasars
       ];
 
   % to retain only unmasked pixels from computed absorption profile
-  ind = (~this_pixel_mask(ind));
+  % this has to be done by using the unmasked_ind which has not yet
+  % been applied this_pixel_mask.
+  ind = (~this_pixel_mask(unmasked_ind));
 
   % compute probabilities under DLA model for each of the sampled
   % (normalized offset, log(N HI)) pairs

--- a/process_qsos.m
+++ b/process_qsos.m
@@ -102,8 +102,6 @@ for quasar_ind = 1:num_quasars
   this_rest_wavelengths = emitted_wavelengths(this_wavelengths, z_qso);
 
   unmasked_ind = (this_rest_wavelengths >= min_lambda) & ...
-        (this_rest_wavelengths <= max_lambda);
-  unmasked_ind = (this_rest_wavelengths >= min_lambda) & ...
                  (this_rest_wavelengths <= max_lambda);
   % keep complete copy of equally spaced wavelengths for absorption
   % computation


### PR DESCRIPTION
Context:
---
We calculated the absorption profile on `this_unmasked_wavelengths`, which are the wavelength pixels without pixel masking. Because we wanted to build the DLA GP model on the masked spectrum, we thus had these two lines before:

```matlab
% absorption on LHS is the masked profile; RHS is the unmasked profile;
% ind has the same size as the unmasked profile.
absorption = absorption(ind);
```
with
```matlab
% to retain only unmasked pixels from computed absorption profile
ind = (~this_pixel_mask(ind));
```

Problem:
----
The `ind` in `~this_pixel_mask(ind)`, however, was assigned as:

```matlab
ind = (this_rest_wavelengths >= min_lambda) & ...
      (this_rest_wavelengths <= max_lambda);

% keep complete copy of equally spaced wavelengths for absorption
% computation
this_unmasked_wavelengths = this_wavelengths(ind);

ind = ind & (~this_pixel_mask);
```
In the last line, the `ind` was re-assigned as an index without pixel masks. This means the line `ind = (~this_pixel_mask(ind));` will return an `ind` with the same shape as the masked spectrum, not unmasked spectrum.

Fix:
---
We can fix this by simply preserving the unmasked `ind`:
```matlab
unmasked_ind = (this_rest_wavelengths >= min_lambda) & ...
      (this_rest_wavelengths <= max_lambda);

% keep complete copy of equally spaced wavelengths for absorption
% computation
this_unmasked_wavelengths = this_wavelengths(unmasked_ind);

ind = unmasked_ind & (~this_pixel_mask);
```
and
```matlab
  ind = (~this_pixel_mask(unmasked_ind));
```

We did not notice this before because MATLAB did not require `absorption` and the `ind` applied on it to have the same size, so `absorption(ind)` did not return error messages. For example `a` and `ind` not having the same size:
```matlab
>> a = [1 2 3 4];
>> ind = [true false true];
>> a(ind)
ans = 
         1   3
```

The difference in the final DLA predictions is very small. This is due to we don't have many masked pixels within our modelling range.

For the first 100 spectra in DR12Q, the maximum difference of the `p_dlas` (before and after this fix) was 0.0085 (for the multi-DLA code), the mean difference was 0.0001